### PR TITLE
feat!: A more accurate (and verbose) nameserver API

### DIFF
--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -332,7 +332,7 @@ mod tests {
     use iroh::{
         RelayUrl, SecretKey,
         address_lookup::{EndpointInfo, PkarrRelayClient},
-        dns::{DNS_TIMEOUT, DnsProtocol, DnsResolver, Nameserver},
+        dns::{DNS_TIMEOUT, DnsProtocol, DnsResolver, NameserverConfig},
         tls::{CaTlsConfig, default_provider},
     };
     use n0_error::StdResultExt;
@@ -430,7 +430,7 @@ mod tests {
             let https_addr = server.https_addr().expect("https is bound");
             DnsResolver::builder()
                 .add_nameserver(
-                    Nameserver::new(https_addr)
+                    NameserverConfig::new(https_addr)
                         .with_protocol(DnsProtocol::Https)
                         .with_tls_server_name("localhost"),
                 )

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -430,8 +430,7 @@ mod tests {
             let https_addr = server.https_addr().expect("https is bound");
             DnsResolver::builder()
                 .add_nameserver(
-                    Nameserver::new(https_addr.ip())
-                        .with_port(https_addr.port())
+                    Nameserver::new(https_addr)
                         .with_protocol(DnsProtocol::Https)
                         .with_tls_server_name("localhost"),
                 )

--- a/iroh-dns-server/src/http.rs
+++ b/iroh-dns-server/src/http.rs
@@ -332,7 +332,7 @@ mod tests {
     use iroh::{
         RelayUrl, SecretKey,
         address_lookup::{EndpointInfo, PkarrRelayClient},
-        dns::{DNS_TIMEOUT, DnsResolver},
+        dns::{DNS_TIMEOUT, DnsProtocol, DnsResolver, Nameserver},
         tls::{CaTlsConfig, default_provider},
     };
     use n0_error::StdResultExt;
@@ -429,7 +429,12 @@ mod tests {
         let resolver = {
             let https_addr = server.https_addr().expect("https is bound");
             DnsResolver::builder()
-                .with_https_nameserver(https_addr, "localhost")
+                .add_nameserver(
+                    Nameserver::new(https_addr.ip())
+                        .with_port(https_addr.port())
+                        .with_protocol(DnsProtocol::Https)
+                        .with_tls_server_name("localhost"),
+                )
                 .tls_client_config(self::tls::insecure_tls_config())
                 .disable_fallback()
                 .build()

--- a/iroh-dns-server/tests/patchbay.rs
+++ b/iroh-dns-server/tests/patchbay.rs
@@ -168,11 +168,7 @@ async fn check_reachable(ip: IpAddr, ports: Ports) -> Result {
     let name = format!("_iroh.{z32}.irohdns.example.");
     for protocol in [DnsProtocol::Udp, DnsProtocol::Tcp] {
         let resolver = DnsResolver::builder()
-            .add_nameserver(
-                Nameserver::new(ip)
-                    .with_port(ports.dns)
-                    .with_protocol(protocol),
-            )
+            .add_nameserver(Nameserver::new((ip, ports.dns)).with_protocol(protocol))
             .build();
         let records: Vec<String> = resolver
             .lookup_txt(&name, Duration::from_secs(5))

--- a/iroh-dns-server/tests/patchbay.rs
+++ b/iroh-dns-server/tests/patchbay.rs
@@ -18,7 +18,7 @@
 
 use std::{net::IpAddr, time::Duration};
 
-use iroh::dns::Nameserver;
+use iroh::dns::NameserverConfig;
 use iroh_base::SecretKey;
 use iroh_dns::{
     dns::{DnsProtocol, DnsResolver},
@@ -168,7 +168,7 @@ async fn check_reachable(ip: IpAddr, ports: Ports) -> Result {
     let name = format!("_iroh.{z32}.irohdns.example.");
     for protocol in [DnsProtocol::Udp, DnsProtocol::Tcp] {
         let resolver = DnsResolver::builder()
-            .add_nameserver(Nameserver::new((ip, ports.dns)).with_protocol(protocol))
+            .add_nameserver(NameserverConfig::new((ip, ports.dns)).with_protocol(protocol))
             .build();
         let records: Vec<String> = resolver
             .lookup_txt(&name, Duration::from_secs(5))

--- a/iroh-dns-server/tests/patchbay.rs
+++ b/iroh-dns-server/tests/patchbay.rs
@@ -16,11 +16,9 @@
 // via a cfg directive
 #![cfg(all(target_os = "linux", not(skip_patchbay)))]
 
-use std::{
-    net::{IpAddr, SocketAddr},
-    time::Duration,
-};
+use std::{net::IpAddr, time::Duration};
 
+use iroh::dns::Nameserver;
 use iroh_base::SecretKey;
 use iroh_dns::{
     dns::{DnsProtocol, DnsResolver},
@@ -170,7 +168,11 @@ async fn check_reachable(ip: IpAddr, ports: Ports) -> Result {
     let name = format!("_iroh.{z32}.irohdns.example.");
     for protocol in [DnsProtocol::Udp, DnsProtocol::Tcp] {
         let resolver = DnsResolver::builder()
-            .with_nameserver(SocketAddr::new(ip, ports.dns), protocol)
+            .add_nameserver(
+                Nameserver::new(ip)
+                    .with_port(ports.dns)
+                    .with_protocol(protocol),
+            )
             .build();
         let records: Vec<String> = resolver
             .lookup_txt(&name, Duration::from_secs(5))

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -265,7 +265,7 @@ impl FallbackMode {
 /// used for the TLS SNI and certificate validation (and as the DoH URL
 /// authority, with the address pinned); otherwise DoT/DoH are addressed by IP.
 #[derive(Debug, Clone)]
-struct Nameserver {
+pub struct Nameserver {
     addr: SocketAddr,
     protocol: DnsProtocol,
     /// Only used for DoT/DoH.
@@ -273,12 +273,80 @@ struct Nameserver {
 }
 
 impl Nameserver {
-    /// Creates a nameserver addressed by IP, with no TLS server name.
-    fn new(addr: SocketAddr, protocol: DnsProtocol) -> Self {
+    /// Creates a UDP Do53 nameserver addressed by IP.
+    ///
+    /// This nameserver will be using DNS over UDP on port 53, see [`Self::with_port`],
+    /// [`Self::with_protocol`] and [`Self::with_tls_server_name`] to further customise this
+    /// nameserver.
+    pub fn new(addr: IpAddr) -> Self {
+        Self {
+            addr: (addr, 53).into(),
+            protocol: DnsProtocol::Udp,
+            server_name: None,
+        }
+    }
+
+    /// Sets the port for the nameserver.
+    ///
+    /// For Do53 this is not usually needed, DoH however will likely require this.
+    ///
+    /// # Returns
+    ///
+    /// A new instance is returned, this struct is essentially a builder for itself.
+    pub fn with_port(self, port: u16) -> Self {
+        let Self {
+            addr,
+            protocol,
+            server_name,
+        } = self;
+        Self {
+            addr: (addr.ip(), port).into(),
+            protocol,
+            server_name,
+        }
+    }
+
+    /// Sets the protocol for the nameserver.
+    ///
+    /// Use this if you want to use DNS over TCP (Do53), TLS (DoT) or HTTPS (DoH). By
+    /// default [`Self::new`] uses DNS over UDP (Do53 as well).
+    ///
+    /// # Returns
+    ///
+    /// A new instance is returned, this struct is essentially a builder for itself.
+    pub fn with_protocol(self, protocol: DnsProtocol) -> Self {
+        let Self {
+            addr,
+            protocol: _,
+            server_name,
+        } = self;
         Self {
             addr,
             protocol,
-            server_name: None,
+            server_name,
+        }
+    }
+
+    /// Sets the TLS server name for the nameserver.
+    ///
+    /// Nameservers are always connected to via IP address. However for the protocols
+    /// running over TLS (DoT & DoH), the server certificate may use a server name rather
+    /// than IP address. When enabled the TLS `ClientHello` will use this server name in the
+    /// SNI.
+    ///
+    /// # Returns
+    ///
+    /// A new instance is returned, this struct is essentially a builder for itself.
+    pub fn with_tls_server_name(self, server_name: impl Into<String>) -> Self {
+        let Self {
+            addr,
+            protocol,
+            server_name: _,
+        } = self;
+        Self {
+            addr,
+            protocol,
+            server_name: Some(server_name.into()),
         }
     }
 
@@ -357,58 +425,48 @@ impl Builder {
         self
     }
 
+    /// Adds a custom nameserver.
+    pub fn add_nameserver(mut self, nameserver: Nameserver) -> Self {
+        self.nameservers.push(nameserver);
+        self
+    }
+
+    /// Adds a list of nameservers.
+    pub fn add_many_nameservers(
+        mut self,
+        nameservers: impl IntoIterator<Item = Nameserver>,
+    ) -> Self {
+        self.nameservers.extend(nameservers);
+        self
+    }
+
     /// Adds a single nameserver, addressed by IP.
     ///
     /// For DNS-over-TLS or DNS-over-HTTPS against a server whose certificate
     /// only covers a hostname, use [`Self::with_tls_nameserver`] or
     /// [`Self::with_https_nameserver`] instead.
+    #[deprecated(since = "1.2.0", note = "Use add_nameserver instead")]
     pub fn with_nameserver(mut self, addr: SocketAddr, protocol: DnsProtocol) -> Self {
-        self.nameservers.push(Nameserver::new(addr, protocol));
-        self
-    }
-
-    /// Adds a list of nameservers, each addressed by IP.
-    pub fn with_nameservers(
-        mut self,
-        nameservers: impl IntoIterator<Item = (SocketAddr, DnsProtocol)>,
-    ) -> Self {
-        self.nameservers.extend(
-            nameservers
-                .into_iter()
-                .map(|(addr, protocol)| Nameserver::new(addr, protocol)),
+        self.nameservers.push(
+            Nameserver::new(addr.ip())
+                .with_port(addr.port())
+                .with_protocol(protocol),
         );
         self
     }
 
-    /// Adds a DNS-over-TLS nameserver with an explicit TLS server name.
-    ///
-    /// The connection is made to `addr`, but `server_name` is used for the SNI
-    /// and certificate validation. Use this for providers whose certificates
-    /// cover a hostname rather than the IP.
-    pub fn with_tls_nameserver(mut self, addr: SocketAddr, server_name: impl Into<String>) -> Self {
-        self.nameservers.push(Nameserver {
-            addr,
-            protocol: DnsProtocol::Tls,
-            server_name: Some(server_name.into()),
-        });
-        self
-    }
-
-    /// Adds a DNS-over-HTTPS nameserver with an explicit server name.
-    ///
-    /// The request is sent to `https://<server_name>/dns-query` with the
-    /// connection pinned to `addr`. Use this for providers whose certificates
-    /// cover a hostname rather than the IP.
-    pub fn with_https_nameserver(
+    /// Adds a list of nameservers, each addressed by IP.
+    #[deprecated(since = "1.2.0", note = "Use add_many_nameservers instead")]
+    pub fn with_nameservers(
         mut self,
-        addr: SocketAddr,
-        server_name: impl Into<String>,
+        nameservers: impl IntoIterator<Item = (SocketAddr, DnsProtocol)>,
     ) -> Self {
-        self.nameservers.push(Nameserver {
-            addr,
-            protocol: DnsProtocol::Https,
-            server_name: Some(server_name.into()),
-        });
+        self.nameservers
+            .extend(nameservers.into_iter().map(|(addr, protocol)| {
+                Nameserver::new(addr.ip())
+                    .with_port(addr.port())
+                    .with_protocol(protocol)
+            }));
         self
     }
 
@@ -427,6 +485,9 @@ impl Builder {
     /// The default is [`FallbackMode::Deferred`]: the fallback nameservers are a
     /// lower-priority tier, queried only when the primary nameservers fail or
     /// time out. See [`FallbackMode`] for the other modes.
+    ///
+    /// The primary reason to use this is to use the system DNS configuration by default but
+    /// fallback to other nameservers if that is not available or those servers do not work.
     pub fn with_fallback_mode(mut self, mode: FallbackMode) -> Self {
         self.fallback_mode = mode;
         self
@@ -439,19 +500,16 @@ impl Builder {
         self.with_fallback_mode(FallbackMode::Never)
     }
 
-    /// Replaces the default public-resolver fallback with the given nameservers,
-    /// each addressed by IP.
+    /// Sets the fallback nameservers to use.
+    ///
+    /// It is suggested to use some DoH (DNS over HTTPS) nameservers as fallback.
     ///
     /// Has no effect when the fallback mode is [`FallbackMode::Never`].
     pub fn with_fallback_nameservers(
         mut self,
-        nameservers: impl IntoIterator<Item = (SocketAddr, DnsProtocol)>,
+        nameservers: impl IntoIterator<Item = Nameserver>,
     ) -> Self {
-        self.fallback_nameservers.extend(
-            nameservers
-                .into_iter()
-                .map(|(addr, protocol)| Nameserver::new(addr, protocol)),
-        );
+        self.fallback_nameservers.extend(nameservers);
         self
     }
 
@@ -677,7 +735,7 @@ impl DnsResolver {
     /// Creates a new DNS resolver configured with a single UDP DNS nameserver.
     pub fn with_nameserver(nameserver: SocketAddr) -> Self {
         Builder::default()
-            .with_nameserver(nameserver, DnsProtocol::Udp)
+            .add_nameserver(Nameserver::new(nameserver.ip()).with_port(nameserver.port()))
             .build()
     }
 
@@ -1173,11 +1231,20 @@ pub(crate) mod tests {
 
     #[test]
     fn builder_named_nameservers_carry_server_name() {
-        let addr = SocketAddr::new(std::net::Ipv4Addr::new(1, 1, 1, 1).into(), 443);
+        let nameserver = Nameserver::new(Ipv4Addr::new(1, 1, 1, 1).into()).with_port(443);
         let builder = Builder::default()
-            .with_nameserver(addr, DnsProtocol::Https)
-            .with_https_nameserver(addr, "cloudflare-dns.com")
-            .with_tls_nameserver(addr, "cloudflare-dns.com");
+            .add_nameserver(nameserver.clone().with_protocol(DnsProtocol::Https))
+            .add_nameserver(
+                nameserver
+                    .clone()
+                    .with_protocol(DnsProtocol::Https)
+                    .with_tls_server_name("cloudflare-dns.com"),
+            )
+            .add_nameserver(
+                nameserver
+                    .with_protocol(DnsProtocol::Tls)
+                    .with_tls_server_name("cloudflare-dns.com"),
+            );
         let ns = &builder.nameservers;
         assert_eq!(ns[0].server_name, None);
         assert_eq!(ns[1].protocol, DnsProtocol::Https);

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -273,36 +273,16 @@ pub struct Nameserver {
 }
 
 impl Nameserver {
-    /// Creates a UDP Do53 nameserver addressed by IP.
+    /// Creates a DNS over UDP nameserver addressed by IP.
     ///
     /// This nameserver will be using DNS over UDP on port 53, see [`Self::with_port`],
     /// [`Self::with_protocol`] and [`Self::with_tls_server_name`] to further customise this
     /// nameserver.
-    pub fn new(addr: IpAddr) -> Self {
+    pub fn new(addr: impl Into<SocketAddr>) -> Self {
         Self {
-            addr: (addr, 53).into(),
+            addr: addr.into(),
             protocol: DnsProtocol::Udp,
             server_name: None,
-        }
-    }
-
-    /// Sets the port for the nameserver.
-    ///
-    /// For Do53 this is not usually needed, DoH however will likely require this.
-    ///
-    /// # Returns
-    ///
-    /// A new instance is returned, this struct is essentially a builder for itself.
-    pub fn with_port(self, port: u16) -> Self {
-        let Self {
-            addr,
-            protocol,
-            server_name,
-        } = self;
-        Self {
-            addr: (addr.ip(), port).into(),
-            protocol,
-            server_name,
         }
     }
 
@@ -447,11 +427,8 @@ impl Builder {
     /// [`Self::with_https_nameserver`] instead.
     #[deprecated(since = "1.2.0", note = "Use add_nameserver instead")]
     pub fn with_nameserver(mut self, addr: SocketAddr, protocol: DnsProtocol) -> Self {
-        self.nameservers.push(
-            Nameserver::new(addr.ip())
-                .with_port(addr.port())
-                .with_protocol(protocol),
-        );
+        self.nameservers
+            .push(Nameserver::new(addr).with_protocol(protocol));
         self
     }
 
@@ -461,12 +438,11 @@ impl Builder {
         mut self,
         nameservers: impl IntoIterator<Item = (SocketAddr, DnsProtocol)>,
     ) -> Self {
-        self.nameservers
-            .extend(nameservers.into_iter().map(|(addr, protocol)| {
-                Nameserver::new(addr.ip())
-                    .with_port(addr.port())
-                    .with_protocol(protocol)
-            }));
+        self.nameservers.extend(
+            nameservers
+                .into_iter()
+                .map(|(addr, protocol)| Nameserver::new(addr).with_protocol(protocol)),
+        );
         self
     }
 
@@ -735,7 +711,7 @@ impl DnsResolver {
     /// Creates a new DNS resolver configured with a single UDP DNS nameserver.
     pub fn with_nameserver(nameserver: SocketAddr) -> Self {
         Builder::default()
-            .add_nameserver(Nameserver::new(nameserver.ip()).with_port(nameserver.port()))
+            .add_nameserver(Nameserver::new(nameserver))
             .build()
     }
 
@@ -1231,17 +1207,16 @@ pub(crate) mod tests {
 
     #[test]
     fn builder_named_nameservers_carry_server_name() {
-        let nameserver = Nameserver::new(Ipv4Addr::new(1, 1, 1, 1).into()).with_port(443);
+        let addr = SocketAddr::new(Ipv4Addr::new(1, 1, 1, 1).into(), 443);
         let builder = Builder::default()
-            .add_nameserver(nameserver.clone().with_protocol(DnsProtocol::Https))
+            .add_nameserver(Nameserver::new(addr).with_protocol(DnsProtocol::Https))
             .add_nameserver(
-                nameserver
-                    .clone()
+                Nameserver::new(addr)
                     .with_protocol(DnsProtocol::Https)
                     .with_tls_server_name("cloudflare-dns.com"),
             )
             .add_nameserver(
-                nameserver
+                Nameserver::new(addr)
                     .with_protocol(DnsProtocol::Tls)
                     .with_tls_server_name("cloudflare-dns.com"),
             );

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -214,9 +214,9 @@ impl<E: StackError + 'static> StaggeredError<E> {
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     use_system_defaults: bool,
-    nameservers: Vec<Nameserver>,
+    nameservers: Vec<NameserverConfig>,
     fallback_mode: FallbackMode,
-    fallback_nameservers: Vec<Nameserver>,
+    fallback_nameservers: Vec<NameserverConfig>,
     #[cfg(not(wasm_browser))]
     tls_client_config: Option<rustls::ClientConfig>,
 }
@@ -265,14 +265,14 @@ impl FallbackMode {
 /// used for the TLS SNI and certificate validation (and as the DoH URL
 /// authority, with the address pinned); otherwise DoT/DoH are addressed by IP.
 #[derive(Debug, Clone)]
-pub struct Nameserver {
+pub struct NameserverConfig {
     addr: SocketAddr,
     protocol: DnsProtocol,
     /// Only used for DoT/DoH.
     server_name: Option<String>,
 }
 
-impl Nameserver {
+impl NameserverConfig {
     /// Creates a DNS over UDP nameserver addressed by IP.
     ///
     /// This nameserver will be using DNS over UDP on port 53, see [`Self::with_port`],
@@ -406,7 +406,7 @@ impl Builder {
     }
 
     /// Adds a custom nameserver.
-    pub fn add_nameserver(mut self, nameserver: Nameserver) -> Self {
+    pub fn add_nameserver(mut self, nameserver: NameserverConfig) -> Self {
         self.nameservers.push(nameserver);
         self
     }
@@ -414,7 +414,7 @@ impl Builder {
     /// Adds a list of nameservers.
     pub fn add_many_nameservers(
         mut self,
-        nameservers: impl IntoIterator<Item = Nameserver>,
+        nameservers: impl IntoIterator<Item = NameserverConfig>,
     ) -> Self {
         self.nameservers.extend(nameservers);
         self
@@ -428,7 +428,7 @@ impl Builder {
     #[deprecated(since = "1.2.0", note = "Use add_nameserver instead")]
     pub fn with_nameserver(mut self, addr: SocketAddr, protocol: DnsProtocol) -> Self {
         self.nameservers
-            .push(Nameserver::new(addr).with_protocol(protocol));
+            .push(NameserverConfig::new(addr).with_protocol(protocol));
         self
     }
 
@@ -441,7 +441,7 @@ impl Builder {
         self.nameservers.extend(
             nameservers
                 .into_iter()
-                .map(|(addr, protocol)| Nameserver::new(addr).with_protocol(protocol)),
+                .map(|(addr, protocol)| NameserverConfig::new(addr).with_protocol(protocol)),
         );
         self
     }
@@ -483,7 +483,7 @@ impl Builder {
     /// Has no effect when the fallback mode is [`FallbackMode::Never`].
     pub fn with_fallback_nameservers(
         mut self,
-        nameservers: impl IntoIterator<Item = Nameserver>,
+        nameservers: impl IntoIterator<Item = NameserverConfig>,
     ) -> Self {
         self.fallback_nameservers.extend(nameservers);
         self
@@ -503,7 +503,7 @@ impl Builder {
             builder = builder.fallback_nameservers(
                 self.fallback_nameservers
                     .into_iter()
-                    .map(Nameserver::into_inner),
+                    .map(NameserverConfig::into_inner),
             );
         }
         #[cfg(not(wasm_browser))]
@@ -711,7 +711,7 @@ impl DnsResolver {
     /// Creates a new DNS resolver configured with a single UDP DNS nameserver.
     pub fn with_nameserver(nameserver: SocketAddr) -> Self {
         Builder::default()
-            .add_nameserver(Nameserver::new(nameserver))
+            .add_nameserver(NameserverConfig::new(nameserver))
             .build()
     }
 
@@ -1209,14 +1209,14 @@ pub(crate) mod tests {
     fn builder_named_nameservers_carry_server_name() {
         let addr = SocketAddr::new(Ipv4Addr::new(1, 1, 1, 1).into(), 443);
         let builder = Builder::default()
-            .add_nameserver(Nameserver::new(addr).with_protocol(DnsProtocol::Https))
+            .add_nameserver(NameserverConfig::new(addr).with_protocol(DnsProtocol::Https))
             .add_nameserver(
-                Nameserver::new(addr)
+                NameserverConfig::new(addr)
                     .with_protocol(DnsProtocol::Https)
                     .with_tls_server_name("cloudflare-dns.com"),
             )
             .add_nameserver(
-                Nameserver::new(addr)
+                NameserverConfig::new(addr)
                     .with_protocol(DnsProtocol::Tls)
                     .with_tls_server_name("cloudflare-dns.com"),
             );


### PR DESCRIPTION
## Description

This makes a more explicit nameserver API, which is more accurate but
also more verbose. The exiting Builder API on it's own was getting
rather messy I think.

I believe this will scale better toward the future as well. E.g. if
each nameserver needs to take its own TLS client config.

## Breaking Changes

Some deprecated APIs:

- `iroh_dns::dns::Builder::with_nameserver` -> `add_nameserver`
- `iroh_dns::dns::Builder::with_nameservers` -> `add_many_nameservers`

The deprecations assume the next release will be 1.2.0 in their annotations.

## Notes & open questions

- This is a PR into the refactor/n0-dns tweaking the API only.

- `iroh_dns::dns::DnsResolver::with_nameserver` is still a
  non-deprecated API in the messy style I think. I'm not sure if
  improving this now achieves much, or even how it should be improved.
  
- When merging this, please adopt the relevant bits of this PR
  description into the other PR.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.