### PR TITLE
refactor(iroh): Clean up mapped addresses constructions

### DIFF
--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1749,9 +1749,11 @@ impl Endpoint {
 
     // # Remaining private methods
 
-    /// Translates a raw [`SocketAddr`] (which may be a synthetic mapped address) into
-    /// a transport address.
-    pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> crate::socket::transports::Addr {
+    /// Translates a possible IP-mapped [`SocketAddr`] into a transport address.
+    pub(crate) fn to_transport_addr(
+        &self,
+        addr: SocketAddr,
+    ) -> Option<crate::socket::transports::Addr> {
         self.inner.to_transport_addr(addr)
     }
 

--- a/iroh/src/endpoint/connection.rs
+++ b/iroh/src/endpoint/connection.rs
@@ -32,7 +32,7 @@ use n0_error::{e, stack_error};
 use n0_future::{TryFutureExt, future::Boxed as BoxFuture, time::Duration};
 use noq::WeakConnectionHandle as NoqWeakConnectionHandle;
 use pin_project::pin_project;
-use tracing::{event, warn};
+use tracing::{error, event, warn};
 
 use super::quic::DecryptedInitial;
 use crate::{
@@ -201,8 +201,13 @@ impl Incoming {
 
     /// Returns the remote address of this incoming connection.
     pub fn remote_addr(&self) -> IncomingAddr {
+        let remote = self.inner.remote_address();
         self.ep
-            .to_transport_addr(self.inner.remote_address())
+            .to_transport_addr(remote)
+            .unwrap_or_else(|| {
+                error!(mapped_addr = ?remote, "Incoming::remote_addr: invalid mapped address");
+                transports::Addr::Ip(remote)
+            })
             .into()
     }
 
@@ -641,8 +646,13 @@ impl Accepting {
 
     /// Returns the remote address of this connection.
     pub fn remote_addr(&self) -> IncomingAddr {
+        let remote = self.inner.remote_address();
         self.ep
-            .to_transport_addr(self.inner.remote_address())
+            .to_transport_addr(remote)
+            .unwrap_or_else(|| {
+                error!(mapped_addr = ?remote, "Accepting::remote_addr: invalid mapped address");
+                transports::Addr::Ip(remote)
+            })
             .into()
     }
 

--- a/iroh/src/socket.rs
+++ b/iroh/src/socket.rs
@@ -521,24 +521,12 @@ impl Socket {
         &self.dns_resolver
     }
 
-    /// Translates a raw [`SocketAddr`] (which may be a synthetic mapped address) into
-    /// a [`transports::Addr`].
+    /// Translates a possible IP-mapped [`SocketAddr`] into a [`transports::Addr`].
     ///
-    /// For regular IP addresses this returns `Addr::Ip`. For synthetic relay-mapped
-    /// IPv6 addresses this performs a reverse lookup and returns `Addr::Relay`.
-    ///
-    /// This lookup only makes sense for a remote address of the
-    /// underlying QUIC connection.
-    ///
-    /// If you call this with a mapped address for which no mapping exists,
-    /// it will return the address as an `Addr::Ip`.
-    pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> transports::Addr {
-        remote_map::to_transport_addr(
-            addr,
-            &self.mapped_addrs.relay_addrs,
-            &self.mapped_addrs.custom_addrs,
-        )
-        .unwrap_or(transports::Addr::Ip(addr))
+    /// For regular IP addresses this returns `Addr::Ip`. For mapped addresses this performs
+    /// a reverse lookup.
+    pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> Option<transports::Addr> {
+        self.mapped_addrs.to_transport_addr(addr)
     }
 
     pub(crate) fn to_local_transport_addr(
@@ -546,7 +534,13 @@ impl Socket {
         local_ip: Option<IpAddr>,
         remote_addr: SocketAddr,
     ) -> LocalTransportAddr {
-        let remote_addr = self.to_transport_addr(remote_addr);
+        let remote_addr = self.to_transport_addr(remote_addr).unwrap_or_else(|| {
+            error!(
+                mapped_addr = ?remote_addr,
+                "Socket::to_local_transport_addr: invalid mapped address",
+            );
+            transports::Addr::Ip(remote_addr)
+        });
         LocalTransportAddr::from_noq_local_ip(
             local_ip,
             &remote_addr,

--- a/iroh/src/socket/remote_map.rs
+++ b/iroh/src/socket/remote_map.rs
@@ -2,6 +2,7 @@ use std::{
     collections::BTreeSet,
     future::poll_fn,
     hash::Hash,
+    net::SocketAddr,
     sync::Arc,
     task::{Context, Poll, Waker, ready},
 };
@@ -31,12 +32,14 @@ pub(crate) use self::remote_state::{
 use super::{
     DirectAddr, Metrics as SocketMetrics,
     mapped_addrs::{
-        AddrMap, CustomMappedAddr, EndpointIdMappedAddr, MultipathMappedAddr, RelayMappedAddr,
+        AddrMap, CustomMappedAddr, EndpointIdMappedAddr, MappedAddr, MultipathMappedAddr,
+        RelayMappedAddr,
     },
     transports,
 };
 use crate::{
     address_lookup::{self, AddressLookupFailed},
+    endpoint::LocalTransportAddr,
     socket::concurrent_read_map::{ConcurrentReadMap, ReadOnlyMap},
 };
 
@@ -78,6 +81,51 @@ pub(crate) struct MappedAddrs {
     pub(super) custom_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
 }
 
+impl MappedAddrs {
+    /// Converts a possibly mapped-IP address into a [`transports::Addr`].
+    pub(crate) fn to_transport_addr(&self, addr: SocketAddr) -> Option<transports::Addr> {
+        to_transport_addr(addr, &self.relay_addrs, &self.custom_addrs)
+    }
+
+    /// Converts a possibly mapped-IP 4-tuple into a [`transports::FourTuple`].
+    pub(crate) fn to_transport_tuple(
+        &self,
+        four_tuple: &noq::FourTuple,
+    ) -> Option<transports::FourTuple> {
+        let remote = to_transport_addr(four_tuple.remote(), &self.relay_addrs, &self.custom_addrs)?;
+        let local = LocalTransportAddr::from_noq_local_ip(
+            four_tuple.local_ip(),
+            &remote,
+            &self.custom_addrs,
+        );
+        Some(transports::FourTuple::new(remote, local))
+    }
+
+    /// Converts a [`transports::FourTuple`] to a mapped-IP 4-tuple.
+    pub(crate) fn to_mapped_tuple(&self, four_tuple: &transports::FourTuple) -> noq::FourTuple {
+        let (remote, local) = match four_tuple {
+            transports::FourTuple::Ip { remote, local } => (*remote, *local),
+            transports::FourTuple::Relay { url, endpoint_id } => (
+                self.relay_addrs
+                    .get(&(url.clone(), *endpoint_id))
+                    .private_socket_addr(),
+                None,
+            ),
+            transports::FourTuple::Custom { remote, local } => {
+                let remote = self.custom_addrs.get(remote).private_socket_addr();
+                let local = local.as_ref().map(|custom_addr| {
+                    self.custom_addrs
+                        .get(custom_addr)
+                        .private_socket_addr()
+                        .ip()
+                });
+                (remote, local)
+            }
+        };
+        noq::FourTuple::new(remote, local)
+    }
+}
+
 /// Converts a mapped socket address to a transport address.
 ///
 /// This takes a socket address, converts it into a [`MultipathMappedAddr`] and then tries
@@ -87,7 +135,7 @@ pub(crate) struct MappedAddrs {
 /// if an entry exists in the corresponding map.
 ///
 /// Returns `None` for [`MultipathMappedAddr::Mixed`] addresses or unknown mapped addresses.
-pub(super) fn to_transport_addr(
+fn to_transport_addr(
     addr: impl Into<MultipathMappedAddr>,
     relay_addrs: &AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
     custom_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
@@ -330,8 +378,7 @@ impl Tasks {
         let sender = RemoteStateActor::new(
             eid,
             self.local_direct_addrs.clone(),
-            mapped_addrs.relay_addrs.clone(),
-            mapped_addrs.custom_addrs.clone(),
+            mapped_addrs.clone(),
             self.metrics.clone(),
             self.address_lookup.clone(),
             self.path_selector.clone(),

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -6,7 +6,7 @@ use std::{
     task::Poll,
 };
 
-use iroh_base::{CustomAddr, EndpointId, RelayUrl, TransportAddr};
+use iroh_base::{EndpointId, TransportAddr};
 use n0_error::StackResultExt;
 use n0_future::{
     FuturesUnordered, MaybeFuture, MergeUnbounded, Stream, StreamExt,
@@ -29,13 +29,12 @@ pub use self::{
     path_watcher::{Path, PathEvent, PathEventStream, PathList, PathListIter, PathListStream},
     remote_info::{RemoteInfo, TransportAddrInfo, TransportAddrUsage},
 };
-use super::Source;
+use super::{MappedAddrs, Source};
 use crate::{
     address_lookup::{AddressLookupFailed, AddressLookupServices, Item as AddressLookupItem},
     endpoint::DirectAddr,
     socket::{
         Metrics as SocketMetrics, RELAY_PATH_MAX_IDLE_TIMEOUT,
-        mapped_addrs::{AddrMap, CustomMappedAddr, RelayMappedAddr},
         remote_map::remote_state::path_watcher::PathStateSender,
         transports::{self, OwnedTransmit, TransportsSender},
     },
@@ -119,10 +118,8 @@ struct State {
     ///
     /// These are our local addresses and any reflexive transport addresses.
     local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
-    /// The mapping between endpoints via a relay and their [`RelayMappedAddr`]s.
-    relay_mapped_addrs: AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
-    /// The mapping between custom transport addresses and their [`CustomMappedAddr`]s.
-    custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
+    /// The mapped addresses for this endpoint.
+    mapped_addrs: MappedAddrs,
     /// Address lookup service, cloned from the socket.
     address_lookup: AddressLookupServices,
 
@@ -177,8 +174,7 @@ impl RemoteStateActor {
     pub(super) fn new(
         endpoint_id: EndpointId,
         local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
-        relay_mapped_addrs: AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
-        custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
+        mapped_addrs: MappedAddrs,
         metrics: Arc<SocketMetrics>,
         address_lookup: AddressLookupServices,
         path_selector: Arc<dyn PathSelector>,
@@ -189,8 +185,7 @@ impl RemoteStateActor {
                 endpoint_id,
                 metrics: metrics.clone(),
                 local_direct_addrs,
-                relay_mapped_addrs,
-                custom_mapped_addrs,
+                mapped_addrs,
                 address_lookup,
                 connections_close: Default::default(),
                 path_events: Default::default(),
@@ -984,7 +979,9 @@ impl State {
         conn_state: &mut ConnectionState,
         path: &noq::Path,
     ) -> Option<transports::FourTuple> {
-        let network_path = self.transport_tuple_for_path(path)?;
+        let network_path = self
+            .mapped_addrs
+            .to_transport_tuple(&path.network_path().ok()?)?;
         event!(
             target: "iroh::_events::path::open",
             Level::DEBUG,
@@ -1036,7 +1033,7 @@ impl State {
         conn_id: ConnId,
         conn_state: &ConnectionState,
         conn: &noq::Connection,
-        open_addr: &transports::FourTuple,
+        open_4tuple: &transports::FourTuple,
     ) {
         // Only the client opens paths; the server receives them via
         // QUIC frames and reacts to PathOpened events.
@@ -1044,15 +1041,14 @@ impl State {
             return;
         }
         // Already open on this connection; nothing to do.
-        if conn_state.paths.values().any(|a| a == open_addr) {
+        if conn_state.paths.values().any(|a| a == open_4tuple) {
             return;
         }
 
-        let quic_addr =
-            open_addr.to_noq_four_tuple(&self.relay_mapped_addrs, &self.custom_mapped_addrs);
-        let path_status = self.path_status_for_addr(open_addr);
+        let mapped_4tuple = self.mapped_addrs.to_mapped_tuple(open_4tuple);
+        let path_status = self.path_status_for_addr(open_4tuple);
 
-        let fut = conn.open_path_ensure(quic_addr, path_status);
+        let fut = conn.open_path_ensure(mapped_4tuple, path_status);
         match fut.path_id() {
             Some(path_id) => {
                 trace!(%conn_id, %path_id, ?path_status, "opening new path");
@@ -1064,8 +1060,8 @@ impl State {
                     | Some(Err(PathError::MaxPathIdReached)) => {
                         self.scheduled_open_path =
                             Some(Instant::now() + Duration::from_millis(333));
-                        self.pending_open_paths.push_back(open_addr.clone());
-                        trace!(?open_addr, ?ret, "scheduling open_path");
+                        self.pending_open_paths.push_back(open_4tuple.clone());
+                        trace!(?open_4tuple, ?ret, "scheduling open_path");
                     }
                     _ => warn!(?ret, "Opening path failed"),
                 }
@@ -1083,16 +1079,6 @@ impl State {
         } else {
             PathStatus::Backup
         }
-    }
-
-    /// Returns the [`transports::FourTuple] for a path.
-    fn transport_tuple_for_path(&self, path: &noq::Path) -> Option<transports::FourTuple> {
-        let noq_network_path = path.network_path().ok()?;
-        transports::FourTuple::from_noq(
-            noq_network_path,
-            &self.relay_mapped_addrs,
-            &self.custom_mapped_addrs,
-        )
     }
 
     /// Returns the current set of local direct addresses.

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -1210,7 +1210,7 @@ struct ConnId(usize);
 ///
 /// - A handle to the connection.
 /// - The paths we know about.
-/// And some stuff to make observers happy.
+/// - Some stuff to make observers happy.
 #[derive(Debug)]
 struct ConnectionState {
     /// Weak handle to the connection.

--- a/iroh/src/socket/remote_map/remote_state.rs
+++ b/iroh/src/socket/remote_map/remote_state.rs
@@ -11,6 +11,7 @@ use n0_error::StackResultExt;
 use n0_future::{
     FuturesUnordered, MaybeFuture, MergeUnbounded, Stream, StreamExt,
     boxed::BoxStream,
+    future::now_or_never,
     task::JoinSet,
     time::{self, Duration, Instant},
 };
@@ -100,7 +101,8 @@ pub(super) struct RemoteStateActor {
     connections: FxHashMap<ConnId, ConnectionState>,
     /// State of the actor and hooks into the rest of the remote endpoint.
     ///
-    /// This is on a separate struct so that we can have parallel mutable borrows to `connections` and `state`.
+    /// This is on a separate struct so that we can have parallel mutable borrows to
+    /// `connections` and `state`.
     state: State,
 }
 
@@ -602,9 +604,10 @@ impl RemoteStateActor {
                     return;
                 };
 
-                // We track all known remote addresses for the peer in `State::paths`. The paths are tracked
-                // by remote address only (we ignore the local IP). Therefore, we mark a remote addr as abandoned
-                // in the remote-global state only once no connections have any path to that remote addr.
+                // We track all known remote addresses for the peer in `State::paths`. The
+                // paths are tracked by remote address only (we ignore the local
+                // IP). Therefore, we mark a remote addr as abandoned in the remote-global
+                // state only once no connections have any path to that remote addr.
                 if !conn_state
                     .paths
                     .values()
@@ -681,8 +684,9 @@ impl RemoteStateActor {
     /// - Sets the selected path to [`PathStatus::Available`]
     fn apply_selected_path(&mut self) {
         let Some(selected) = self.state.selected_path.clone() else {
-            // We can't open the selected path on all paths if we don't have one yet.
-            // And we can't close all "unselected" paths either, because we don't know which one is selected.
+            // We can't open the selected path on all paths if we don't have one yet.  And
+            // we can't close all "unselected" paths either, because we don't know which one
+            // is selected.
             return;
         };
 
@@ -695,7 +699,7 @@ impl RemoteStateActor {
             self.state
                 .open_path_on_conn(*conn_id, conn_state, &conn, &selected);
 
-            for (path_id, path_remote) in conn_state.paths.iter() {
+            for (path_id, path_fourtuple) in conn_state.paths.iter() {
                 let Some(path) = conn.path(*path_id) else {
                     continue;
                 };
@@ -706,11 +710,11 @@ impl RemoteStateActor {
                 // to avoid the client and server independently closing different paths
                 // and racing to abandon the last one.
                 if conn.side().is_client()
-                    && path_remote.is_ip()
-                    && path_remote != &selected
+                    && path_fourtuple.is_ip()
+                    && path_fourtuple != &selected
                     && conn_state.paths.values().filter(|a| a.is_ip()).count() > 1
                 {
-                    trace!(?path_remote, %conn_id, %path_id, "closing direct path");
+                    trace!(?path_fourtuple, %conn_id, %path_id, "closing direct path");
                     match path.close() {
                         Err(noq_proto::ClosePathError::MultipathNotNegotiated) => {
                             error!("multipath not negotiated");
@@ -726,8 +730,9 @@ impl RemoteStateActor {
                     continue;
                 }
 
-                // Set path status: The selected path becomes Available, all other paths become Backup.
-                self.state.set_path_status(*conn_id, &path, path_remote);
+                // Set path status: The selected path becomes Available, all other paths
+                // become Backup.
+                self.state.set_path_status(*conn_id, &path, path_fourtuple);
             }
 
             // Record the new selected path in the path watcher.
@@ -1215,7 +1220,11 @@ struct HolepunchAttempt {
 #[display("{_0}")]
 struct ConnId(usize);
 
-/// State about one connection.
+/// A connection managed by the [`RemoteStateActor`].
+///
+/// - A handle to the connection.
+/// - The paths we know about.
+/// And some stuff to make observers happy.
 #[derive(Debug)]
 struct ConnectionState {
     /// Weak handle to the connection.
@@ -1227,6 +1236,13 @@ struct ConnectionState {
     /// [`Connection`]: crate::endpoint::Connection
     path_state: PathStateSender,
     /// The open paths that exist on this connection.
+    ///
+    /// This might be lagging from the connection state inside noq itself as this can only
+    /// be updated once we received the event from noq.
+    ///
+    /// IP paths *should* have the local IP address filled in by the time we receive the
+    /// event. The noq established event is only emitted once at least one datagram is
+    /// received from the peer on the path.
     paths: FxHashMap<PathId, transports::FourTuple>,
     /// Whether this connection has ever had a direct path.
     ///
@@ -1466,15 +1482,6 @@ impl PathSelection {
     /// Returns `None` when nothing has been selected.
     pub(crate) fn selected(&self) -> Option<&transports::FourTuple> {
         self.selection.as_ref()
-    }
-}
-
-/// Poll a future once, like n0_future::future::poll_once but sync.
-fn now_or_never<T, F: Future<Output = T>>(fut: F) -> Option<T> {
-    let fut = std::pin::pin!(fut);
-    match fut.poll(&mut std::task::Context::from_waker(std::task::Waker::noop())) {
-        Poll::Ready(res) => Some(res),
-        Poll::Pending => None,
     }
 }
 

--- a/iroh/src/socket/remote_map/remote_state/path_state.rs
+++ b/iroh/src/socket/remote_map/remote_state/path_state.rs
@@ -250,7 +250,9 @@ pub(super) struct PathState {
 ///
 /// - We do not have unbounded growth of paths.
 /// - If we have many paths for this remote, we prune the paths that cannot hole punch.
-/// - We do not prune holepunched paths that are currently not in use too quickly. For example, if a large number of untested paths are added at once, we will not immediately prune all of the unused, but valid, paths at once.
+/// - We do not prune holepunched paths that are currently not in use too quickly. For
+///   example, if a large number of untested paths are added at once, we will not
+///   immediately prune all of the unused, but valid, paths at once.
 fn prune_non_relay_paths(paths: &mut FxHashMap<transports::Addr, PathState>) {
     // if the total number of paths is less than the max, bail early
     if paths.len() < MAX_NON_RELAY_PATHS {

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -890,7 +890,10 @@ impl Addr {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum LocalTransportAddr {
-    /// The local IP, if the OS surfaced it.
+    /// The local IP.
+    ///
+    /// This is almost always present, only some very old operating systems do not support
+    /// it.
     Ip(Option<IpAddr>),
     /// The relay over which this network path is connected.
     Relay(RelayUrl),

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -21,10 +21,7 @@ use crate::{
     endpoint::RelayStatus,
     metrics::EndpointMetrics,
     net_report::Report,
-    socket::{
-        mapped_addrs::{AddrMap, CustomMappedAddr, MappedAddr, RelayMappedAddr},
-        remote_map::to_transport_addr,
-    },
+    socket::mapped_addrs::{AddrMap, CustomMappedAddr},
 };
 
 pub(crate) mod custom;
@@ -500,161 +497,6 @@ impl Transports {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-
-    use n0_watcher::Watchable;
-
-    use super::*;
-
-    const FAIRNESS_SAMPLE_POLLS: usize = 10_000;
-
-    #[test]
-    fn ready_custom_transports_are_polled_fairly() {
-        // GIVEN: two custom transport lanes that are always ready.
-        let first_polls = Arc::new(AtomicUsize::new(0));
-        let second_polls = Arc::new(AtomicUsize::new(0));
-        let mut transports = custom_only_transports(vec![
-            ready_custom_endpoint(1, first_polls.clone()),
-            ready_custom_endpoint(2, second_polls.clone()),
-        ]);
-
-        // WHEN: receive polling runs long enough to exercise both polling orders.
-        let selected =
-            sample_ready_custom_transport_selection(&mut transports, FAIRNESS_SAMPLE_POLLS);
-
-        let first_selected = selected.iter().filter(|&&id| id == 1).count();
-        let second_selected = selected.iter().filter(|&&id| id == 2).count();
-
-        // THEN: selection and actual polling are split evenly between lanes.
-        assert_eq!(first_selected, FAIRNESS_SAMPLE_POLLS / 2);
-        assert_eq!(second_selected, FAIRNESS_SAMPLE_POLLS / 2);
-        assert_eq!(
-            first_polls.load(Ordering::Relaxed),
-            FAIRNESS_SAMPLE_POLLS / 2
-        );
-        assert_eq!(
-            second_polls.load(Ordering::Relaxed),
-            FAIRNESS_SAMPLE_POLLS / 2
-        );
-
-        // And the lane order alternates from the first poll.
-        assert_eq!(
-            selected.iter().take(4).copied().collect::<Vec<_>>(),
-            vec![2, 1, 2, 1],
-        );
-    }
-
-    fn custom_only_transports(custom: Vec<Box<dyn CustomEndpoint>>) -> Transports {
-        let metrics = EndpointMetrics::default();
-        Transports {
-            #[cfg(not(wasm_browser))]
-            ip: ip::IpTransports::bind(std::iter::empty(), &metrics).unwrap(),
-            relay: Vec::new(),
-            custom,
-            poll_recv_counter: 0,
-            recv_infos: Default::default(),
-            consecutive_total_recv_failures: 0,
-        }
-    }
-
-    fn ready_custom_endpoint(id: u8, polls: Arc<AtomicUsize>) -> Box<dyn CustomEndpoint> {
-        Box::new(ReadyCustomEndpoint {
-            id,
-            polls,
-            local_addr: CustomAddr::from_parts(1, &[id]),
-            remote_addr: CustomAddr::from_parts(2, &[id]),
-            local_addr_watch: Watchable::new(vec![CustomAddr::from_parts(1, &[id])]),
-        })
-    }
-
-    fn sample_ready_custom_transport_selection(
-        transports: &mut Transports,
-        polls: usize,
-    ) -> Vec<u8> {
-        let mut selected = Vec::with_capacity(polls);
-        let waker = futures_util::task::noop_waker();
-        let mut cx = Context::from_waker(&waker);
-        let mut storage = [0u8; 1];
-        let mut metas = [noq_udp::RecvMeta::default()];
-
-        for _ in 0..polls {
-            let mut bufs = [IoSliceMut::new(&mut storage)];
-            let n = match transports.inner_poll_recv(&mut cx, &mut bufs, &mut metas) {
-                Poll::Ready(Ok(n)) => n,
-                Poll::Ready(Err(err)) => panic!("custom transport poll failed: {err}"),
-                Poll::Pending => panic!("ready custom transport returned pending"),
-            };
-            assert_eq!(n, 1);
-            selected.push(storage[0]);
-            storage[0] = 0;
-            metas[0] = noq_udp::RecvMeta::default();
-        }
-
-        selected
-    }
-
-    #[derive(Debug)]
-    struct ReadyCustomEndpoint {
-        id: u8,
-        polls: Arc<AtomicUsize>,
-        local_addr: CustomAddr,
-        remote_addr: CustomAddr,
-        local_addr_watch: Watchable<Vec<CustomAddr>>,
-    }
-
-    impl CustomEndpoint for ReadyCustomEndpoint {
-        fn watch_local_addrs(&self) -> n0_watcher::Direct<Vec<CustomAddr>> {
-            self.local_addr_watch.watch()
-        }
-
-        fn create_sender(&self) -> Arc<dyn CustomSender> {
-            Arc::new(NoopCustomSender)
-        }
-
-        fn poll_recv(
-            &mut self,
-            _cx: &mut Context,
-            bufs: &mut [io::IoSliceMut<'_>],
-            metas: &mut [noq_udp::RecvMeta],
-            recv_infos: &mut [RecvInfo],
-        ) -> Poll<io::Result<usize>> {
-            self.polls.fetch_add(1, Ordering::Relaxed);
-            bufs[0][0] = self.id;
-            metas[0].len = 1;
-            metas[0].stride = 1;
-            recv_infos[0] = RecvInfo {
-                remote: Addr::Custom(self.remote_addr.clone()),
-                local: Some(self.local_addr.clone()),
-            };
-            Poll::Ready(Ok(1))
-        }
-    }
-
-    #[derive(Debug)]
-    struct NoopCustomSender;
-
-    impl CustomSender for NoopCustomSender {
-        fn is_valid_send_addr(&self, _addr: &CustomAddr) -> bool {
-            false
-        }
-
-        fn poll_send(
-            &self,
-            _cx: &mut Context,
-            _dst: &CustomAddr,
-            _src: Option<&CustomAddr>,
-            _transmit: &Transmit<'_>,
-        ) -> Poll<io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct NetworkChangeSender {
     #[cfg(not(wasm_browser))]
@@ -1043,25 +885,6 @@ impl FourTuple {
         }
     }
 
-    /// Returns the [`FourTuple] for a noq network path by looking up QUIC-mapped addresses.
-    pub(super) fn from_noq(
-        noq_four_tuple: noq::FourTuple,
-        relay_mapped_addrs: &AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
-        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
-    ) -> Option<Self> {
-        let remote = to_transport_addr(
-            noq_four_tuple.remote(),
-            relay_mapped_addrs,
-            custom_mapped_addrs,
-        )?;
-        let local = LocalTransportAddr::from_noq_local_ip(
-            noq_four_tuple.local_ip(),
-            &remote,
-            custom_mapped_addrs,
-        );
-        Some(Self::new(remote, local))
-    }
-
     /// Returns the remote transport address.
     pub fn remote(&self) -> Addr {
         match self {
@@ -1088,34 +911,6 @@ impl FourTuple {
     /// Returns `true` if the remote is a relay address.
     pub fn is_relay(&self) -> bool {
         matches!(self, Self::Relay { .. })
-    }
-
-    /// Returns the QUIC-mapped [`noq::FourTuple`] for this [`FourTuple`].
-    pub(super) fn to_noq_four_tuple(
-        &self,
-        relay_mapped_addrs: &AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
-        custom_mapped_addrs: &AddrMap<CustomAddr, CustomMappedAddr>,
-    ) -> noq::FourTuple {
-        let (remote, local) = match self {
-            FourTuple::Ip { remote, local } => (*remote, *local),
-            FourTuple::Relay { url, endpoint_id } => (
-                relay_mapped_addrs
-                    .get(&(url.clone(), *endpoint_id))
-                    .private_socket_addr(),
-                None,
-            ),
-            FourTuple::Custom { remote, local } => {
-                let remote = custom_mapped_addrs.get(remote).private_socket_addr();
-                let local = local.as_ref().map(|custom_addr| {
-                    custom_mapped_addrs
-                        .get(custom_addr)
-                        .private_socket_addr()
-                        .ip()
-                });
-                (remote, local)
-            }
-        };
-        noq::FourTuple::new(remote, local)
     }
 
     /// Returns the kind of address, for configuring bias.
@@ -1506,5 +1301,160 @@ impl noq::UdpSender for Sender {
 
     fn max_transmit_segments(&self) -> NonZeroUsize {
         self.sender.max_transmit_segments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use n0_watcher::Watchable;
+
+    use super::*;
+
+    const FAIRNESS_SAMPLE_POLLS: usize = 10_000;
+
+    #[test]
+    fn ready_custom_transports_are_polled_fairly() {
+        // GIVEN: two custom transport lanes that are always ready.
+        let first_polls = Arc::new(AtomicUsize::new(0));
+        let second_polls = Arc::new(AtomicUsize::new(0));
+        let mut transports = custom_only_transports(vec![
+            ready_custom_endpoint(1, first_polls.clone()),
+            ready_custom_endpoint(2, second_polls.clone()),
+        ]);
+
+        // WHEN: receive polling runs long enough to exercise both polling orders.
+        let selected =
+            sample_ready_custom_transport_selection(&mut transports, FAIRNESS_SAMPLE_POLLS);
+
+        let first_selected = selected.iter().filter(|&&id| id == 1).count();
+        let second_selected = selected.iter().filter(|&&id| id == 2).count();
+
+        // THEN: selection and actual polling are split evenly between lanes.
+        assert_eq!(first_selected, FAIRNESS_SAMPLE_POLLS / 2);
+        assert_eq!(second_selected, FAIRNESS_SAMPLE_POLLS / 2);
+        assert_eq!(
+            first_polls.load(Ordering::Relaxed),
+            FAIRNESS_SAMPLE_POLLS / 2
+        );
+        assert_eq!(
+            second_polls.load(Ordering::Relaxed),
+            FAIRNESS_SAMPLE_POLLS / 2
+        );
+
+        // And the lane order alternates from the first poll.
+        assert_eq!(
+            selected.iter().take(4).copied().collect::<Vec<_>>(),
+            vec![2, 1, 2, 1],
+        );
+    }
+
+    fn custom_only_transports(custom: Vec<Box<dyn CustomEndpoint>>) -> Transports {
+        let metrics = EndpointMetrics::default();
+        Transports {
+            #[cfg(not(wasm_browser))]
+            ip: ip::IpTransports::bind(std::iter::empty(), &metrics).unwrap(),
+            relay: Vec::new(),
+            custom,
+            poll_recv_counter: 0,
+            recv_infos: Default::default(),
+            consecutive_total_recv_failures: 0,
+        }
+    }
+
+    fn ready_custom_endpoint(id: u8, polls: Arc<AtomicUsize>) -> Box<dyn CustomEndpoint> {
+        Box::new(ReadyCustomEndpoint {
+            id,
+            polls,
+            local_addr: CustomAddr::from_parts(1, &[id]),
+            remote_addr: CustomAddr::from_parts(2, &[id]),
+            local_addr_watch: Watchable::new(vec![CustomAddr::from_parts(1, &[id])]),
+        })
+    }
+
+    fn sample_ready_custom_transport_selection(
+        transports: &mut Transports,
+        polls: usize,
+    ) -> Vec<u8> {
+        let mut selected = Vec::with_capacity(polls);
+        let waker = futures_util::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut storage = [0u8; 1];
+        let mut metas = [noq_udp::RecvMeta::default()];
+
+        for _ in 0..polls {
+            let mut bufs = [IoSliceMut::new(&mut storage)];
+            let n = match transports.inner_poll_recv(&mut cx, &mut bufs, &mut metas) {
+                Poll::Ready(Ok(n)) => n,
+                Poll::Ready(Err(err)) => panic!("custom transport poll failed: {err}"),
+                Poll::Pending => panic!("ready custom transport returned pending"),
+            };
+            assert_eq!(n, 1);
+            selected.push(storage[0]);
+            storage[0] = 0;
+            metas[0] = noq_udp::RecvMeta::default();
+        }
+
+        selected
+    }
+
+    #[derive(Debug)]
+    struct ReadyCustomEndpoint {
+        id: u8,
+        polls: Arc<AtomicUsize>,
+        local_addr: CustomAddr,
+        remote_addr: CustomAddr,
+        local_addr_watch: Watchable<Vec<CustomAddr>>,
+    }
+
+    impl CustomEndpoint for ReadyCustomEndpoint {
+        fn watch_local_addrs(&self) -> n0_watcher::Direct<Vec<CustomAddr>> {
+            self.local_addr_watch.watch()
+        }
+
+        fn create_sender(&self) -> Arc<dyn CustomSender> {
+            Arc::new(NoopCustomSender)
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut Context,
+            bufs: &mut [io::IoSliceMut<'_>],
+            metas: &mut [noq_udp::RecvMeta],
+            recv_infos: &mut [RecvInfo],
+        ) -> Poll<io::Result<usize>> {
+            self.polls.fetch_add(1, Ordering::Relaxed);
+            bufs[0][0] = self.id;
+            metas[0].len = 1;
+            metas[0].stride = 1;
+            recv_infos[0] = RecvInfo {
+                remote: Addr::Custom(self.remote_addr.clone()),
+                local: Some(self.local_addr.clone()),
+            };
+            Poll::Ready(Ok(1))
+        }
+    }
+
+    #[derive(Debug)]
+    struct NoopCustomSender;
+
+    impl CustomSender for NoopCustomSender {
+        fn is_valid_send_addr(&self, _addr: &CustomAddr) -> bool {
+            false
+        }
+
+        fn poll_send(
+            &self,
+            _cx: &mut Context,
+            _dst: &CustomAddr,
+            _src: Option<&CustomAddr>,
+            _transmit: &Transmit<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
     }
 }


### PR DESCRIPTION
## Description

This cleans up all the ways mapped addresses are constructed. They got
out of hand with things moving all over the place and being
duplicated. It was also too easy to silently violate some invariants.

We still have some invariants that can be violated. This now logs them
and returns the wrong results as before. The other option is to
.expect() them. But they're being held across an extremely-long chain:
noq will get fake addresses on poll_recv which then have to map back
when the users asks for which addresses those are.

## Breaking Changes

none

## Notes & open questions

This also moves a block of tests around that got lost.

This all started because the relay and custom addrs usage in the
RemoteStateActor was getting wieldy. Turns out MappedAddrs already
existed and we were starting to duplicate a lot. Initially this wasn't
used there because this also includes the EndpointId-mapped addresses,
which the RemoteStateActor does not need. But it seems better now to
live with that bit of data access than build yet another struct with
the other two maps. Though I could be convinced the latter is better.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.