### PR TITLE
deps: Upgrade to non-yanked chacha20 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,9 +585,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,8 +2778,7 @@ dependencies = [
 [[package]]
 name = "n0-error"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
+source = "git+https://github.com/n0-computer/n0-error#08af94355f3dab4a5952351c710c63747206dd4b"
 dependencies = [
  "anyhow",
  "n0-error-macros",
@@ -2789,8 +2788,7 @@ dependencies = [
 [[package]]
 name = "n0-error-macros"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
+source = "git+https://github.com/n0-computer/n0-error#08af94355f3dab4a5952351c710c63747206dd4b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,6 @@ trait_method_marked_deprecated = { required-update = "minor" }
 type_associated_const_marked_deprecated = { required-update = "minor" }
 type_marked_deprecated = { required-update = "minor" }
 type_method_marked_deprecated = { required-update = "minor" }
+
+[patch.crates-io]
+n0-error = { git = "https://github.com/n0-computer/n0-error" }

--- a/deny.toml
+++ b/deny.toml
@@ -27,4 +27,6 @@ ignore = [
 ]
 
 [sources]
-allow-git = []
+allow-git = [
+  "https://github.com/n0-computer/n0-error",
+]


### PR DESCRIPTION
## Description

Previous versions contained some UB.

## Breaking Changes

none

## Notes & open questions

Also uses https://github.com/n0-computer/n0-error/pull/61, n0-error needs a new
release really.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.