### PR TITLE
deps: Bump n0-error version, remove patch

### DIFF
--- a/.github/workflows/minimal-crates.yaml
+++ b/.github/workflows/minimal-crates.yaml
@@ -12,8 +12,6 @@ concurrency:
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: -Dwarnings
-  RUSTDOCFLAGS: -Dwarnings
   SCCACHE_CACHE_SIZE: "10G"
 
 # Default to read-only; jobs that need more grant it explicitly.

--- a/.github/workflows/netsim_runner.yaml
+++ b/.github/workflows/netsim_runner.yaml
@@ -148,6 +148,7 @@ jobs:
     - name: Fetch netsim
       env:
         NETSIM_BRANCH: ${{ inputs.netsim_branch }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         cd ..
         rm -rf chuck

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
+checksum = "4412346410d6616f3668c40e53c298e5320c7b856f7a960e5914e442601be79f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,8 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "1.0.0"
-source = "git+https://github.com/n0-computer/n0-error#08af94355f3dab4a5952351c710c63747206dd4b"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c59ea174675ce6bc196878851e5049e11b8b1f9af3ba87e4d6df8d828bb001"
 dependencies = [
  "anyhow",
  "n0-error-macros",
@@ -2788,7 +2789,8 @@ dependencies = [
 [[package]]
 name = "n0-error-macros"
 version = "1.0.0"
-source = "git+https://github.com/n0-computer/n0-error#08af94355f3dab4a5952351c710c63747206dd4b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,3 @@ trait_method_marked_deprecated = { required-update = "minor" }
 type_associated_const_marked_deprecated = { required-update = "minor" }
 type_marked_deprecated = { required-update = "minor" }
 type_method_marked_deprecated = { required-update = "minor" }
-
-[patch.crates-io]
-n0-error = { git = "https://github.com/n0-computer/n0-error" }

--- a/deny.toml
+++ b/deny.toml
@@ -28,5 +28,4 @@ ignore = [
 
 [sources]
 allow-git = [
-  "https://github.com/n0-computer/n0-error",
 ]


### PR DESCRIPTION
## Description

This uses the new n0-error release instead of the patch from before.

It also disables the "deny warnings" compiler options for the minimal-crates
check. It seems we can not keep this empty of warnings without having to
make our dependencies needlessly tight.


## Breaking Changes

none

## Notes & open questions

none

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.