### PR TITLE
feat(iroh): add `RelayStatus::auth_denied_reason` and example

### DIFF
--- a/iroh/Cargo.toml
+++ b/iroh/Cargo.toml
@@ -249,3 +249,7 @@ required-features = ["tls-aws-lc-rs"]
 [[example]]
 name = "prefer-pq-key-exchange"
 required-features = ["tls-aws-lc-rs"]
+
+[[example]]
+name = "home-relay-status"
+required-features = []

--- a/iroh/examples/home-relay-status.rs
+++ b/iroh/examples/home-relay-status.rs
@@ -1,0 +1,111 @@
+//! Tests connection to a home relay server and reports the status.
+//!
+//! Also shows how to specifically test if a connection fails due to authentication.
+
+use clap::Parser;
+use iroh::{Endpoint, RelayMap, RelayUrl, Watcher, endpoint::presets};
+use iroh_relay::protos::handshake;
+use n0_error::{AnyError, StackError};
+use n0_future::StreamExt;
+
+#[derive(clap::Parser, Debug)]
+struct Args {
+    /// Pass one or more relay URLs.
+    ///
+    /// If unset will use the public default relays.
+    relays: Vec<RelayUrl>,
+}
+
+#[tokio::main]
+async fn main() -> n0_error::Result<()> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+    let relay_map = if args.relays.is_empty() {
+        iroh::defaults::prod::default_relay_map()
+    } else {
+        RelayMap::from_iter(args.relays)
+    };
+
+    let endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(iroh::RelayMode::Custom(relay_map))
+        .bind()
+        .await?;
+
+    println!("endpoint bound");
+
+    // Spawn a task to report the home relay status.
+    //
+    // You could pass a channel here if you wanted to abort something in case the
+    // home relay connection fails.
+    tokio::spawn(report_home_relay_status(endpoint.clone()));
+
+    // Wait for the endpoint to be online, i.e. connected to a home relay.
+    //
+    // This is like a simplified version of the above loop, only caring about
+    // whether a connection was established and not reporting any details in case
+    // of failure.
+    endpoint.online().await;
+    println!(
+        "Endpoint is online. Home relay: {}",
+        endpoint.addr().relay_urls().next().expect("has relay")
+    );
+
+    tokio::signal::ctrl_c().await.ok();
+
+    endpoint.close().await;
+
+    Ok(())
+}
+
+async fn report_home_relay_status(endpoint: Endpoint) {
+    let mut home_relay_status = endpoint.home_relay_status().stream();
+    // The stream moves to the next item whenever the home relay status changes in any way.
+    while let Some(status_list) = home_relay_status.next().await {
+        // The stream's item is a list of status items for each home relay.
+        // Currently, it is always a single item only, because iroh only connects to a single
+        // home relay. It is a list so that iroh could in the future have multiple home relays
+        // without API change.
+        let Some(status) = status_list.into_iter().next() else {
+            continue;
+        };
+        let url = status.url();
+        if status.is_connected() {
+            // We are connected!
+            // When we reach this line, `Endpoint::online` also resolves.
+            println!("Relay {url}: Connected");
+        } else if let Some(error) = status.last_error() {
+            // We are not connected, and we have an error from the last connection failure
+            // or failed connection attempt. The error is a `AnyError`. We can try to downcast
+            // it to a more specific type!
+            if let Some(auth_denial_reason) = is_auth_denied(&error) {
+                // The home relay connection failed due to authentication. We could report this
+                // prominently in our app.
+                println!("Relay {url}: Authentication denied ({auth_denial_reason})");
+            } else {
+                // The home relay connection failed due to another error, for example network
+                // issues. Let's just print it.
+                println!("Relay {url}: Connection failed ({error:#})");
+            }
+        } else {
+            // We are disconnected without an error state. This is the state before a
+            // connection attempt. You should usually just loop over it and wait for
+            // the next error.
+            println!("Relay {url}: Disconnected")
+        }
+    }
+}
+
+/// Returns the reason if `error` was caused by the relay server denying our authentication.
+///
+/// Relay connection errors are reported as an [`AnyError`] that wraps a chain of
+/// crate-private error types from `iroh`. The innermost source, however, is the public
+/// [`handshake::Error`] from `iroh-relay`, so we walk the source chain and downcast to
+/// find a [`handshake::Error::ServerDeniedAuth`].
+fn is_auth_denied(error: &AnyError) -> Option<String> {
+    error
+        .stack()
+        .find_map(|error| match error.downcast_ref::<handshake::Error>()? {
+            handshake::Error::ServerDeniedAuth { reason, .. } => Some(reason.clone()),
+            _ => None,
+        })
+}

--- a/iroh/examples/home-relay-status.rs
+++ b/iroh/examples/home-relay-status.rs
@@ -4,8 +4,6 @@
 
 use clap::Parser;
 use iroh::{Endpoint, RelayMap, RelayUrl, Watcher, endpoint::presets};
-use iroh_relay::protos::handshake;
-use n0_error::{AnyError, StackError};
 use n0_future::StreamExt;
 
 #[derive(clap::Parser, Debug)]
@@ -41,9 +39,9 @@ async fn main() -> n0_error::Result<()> {
 
     // Wait for the endpoint to be online, i.e. connected to a home relay.
     //
-    // This is like a simplified version of the above loop, only caring about
-    // whether a connection was established and not reporting any details in case
-    // of failure.
+    // Internally, this works like simplified version of the loop in `report_home_relay_status`,
+    // only reporting about whether a connection was established and not exposing any
+    // details in case of failure.
     endpoint.online().await;
     println!(
         "Endpoint is online. Home relay: {}",
@@ -61,51 +59,31 @@ async fn report_home_relay_status(endpoint: Endpoint) {
     let mut home_relay_status = endpoint.home_relay_status().stream();
     // The stream moves to the next item whenever the home relay status changes in any way.
     while let Some(status_list) = home_relay_status.next().await {
-        // The stream's item is a list of status items for each home relay.
-        // Currently, it is always a single item only, because iroh only connects to a single
-        // home relay. It is a list so that iroh could in the future have multiple home relays
-        // without API change.
-        let Some(status) = status_list.into_iter().next() else {
-            continue;
-        };
-        let url = status.url();
-        if status.is_connected() {
-            // We are connected!
-            // When we reach this line, `Endpoint::online` also resolves.
-            println!("Relay {url}: Connected");
-        } else if let Some(error) = status.last_error() {
-            // We are not connected, and we have an error from the last connection failure
-            // or failed connection attempt. The error is a `AnyError`. We can try to downcast
-            // it to a more specific type!
-            if let Some(auth_denial_reason) = is_auth_denied(error) {
-                // The home relay connection failed due to authentication. We could report this
-                // prominently in our app.
-                println!("Relay {url}: Authentication denied ({auth_denial_reason})");
-            } else {
-                // The home relay connection failed due to another error, for example network
-                // issues. Let's just print it.
+        // The stream's item is a list of status entries, one per home relay. Today the list
+        // never holds more than one entry, because iroh only connects to a single home
+        // relay. It is a list so that iroh could support multiple home relays without an API
+        // change, so we may as well iterate it.
+        for status in status_list {
+            let url = status.url();
+            if status.is_connected() {
+                // We are connected!
+                // When we reach this line, `Endpoint::online` also resolves.
+                println!("Relay {url}: Connected");
+            } else if let Some(reason) = status.auth_denied_reason() {
+                // The relay server denied our authentication. Retrying will not help: we
+                // would present the same credentials again. Report this prominently in
+                // our app instead of waiting to come online.
+                println!("Relay {url}: Authentication denied ({reason})");
+            } else if let Some(error) = status.last_error() {
+                // The connection failed for another reason, for example a network issue.
+                // iroh keeps retrying with a backoff, so let's just print it.
                 println!("Relay {url}: Connection failed ({error:#})");
+            } else {
+                // We are not connected, and there is no error to report: either no
+                // connection has been attempted yet, or one is in progress. You should
+                // usually just loop over this and wait for the next update.
+                println!("Relay {url}: Disconnected")
             }
-        } else {
-            // We are disconnected without an error state. This is the state before a
-            // connection attempt. You should usually just loop over it and wait for
-            // the next error.
-            println!("Relay {url}: Disconnected")
         }
     }
-}
-
-/// Returns the reason if `error` was caused by the relay server denying our authentication.
-///
-/// Relay connection errors are reported as an [`AnyError`] that wraps a chain of
-/// crate-private error types from `iroh`. The innermost source, however, is the public
-/// [`handshake::Error`] from `iroh-relay`, so we walk the source chain and downcast to
-/// find a [`handshake::Error::ServerDeniedAuth`].
-fn is_auth_denied(error: &AnyError) -> Option<String> {
-    error
-        .stack()
-        .find_map(|error| match error.downcast_ref::<handshake::Error>()? {
-            handshake::Error::ServerDeniedAuth { reason, .. } => Some(reason.clone()),
-            _ => None,
-        })
 }

--- a/iroh/examples/home-relay-status.rs
+++ b/iroh/examples/home-relay-status.rs
@@ -77,7 +77,7 @@ async fn report_home_relay_status(endpoint: Endpoint) {
             // We are not connected, and we have an error from the last connection failure
             // or failed connection attempt. The error is a `AnyError`. We can try to downcast
             // it to a more specific type!
-            if let Some(auth_denial_reason) = is_auth_denied(&error) {
+            if let Some(auth_denial_reason) = is_auth_denied(error) {
                 // The home relay connection failed due to authentication. We could report this
                 // prominently in our app.
                 println!("Relay {url}: Authentication denied ({auth_denial_reason})");

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -74,8 +74,10 @@ use crate::{
     metrics::EndpointMetrics,
     socket::{
         self, EndpointInner, RemoteStateActorStoppedError, StaticConfig,
-        biased_rtt_path_selector::BiasedRttPathSelector, mapped_addrs::MappedAddr,
-        remote_map::PathSelector, transports::RelayConnectionState,
+        biased_rtt_path_selector::BiasedRttPathSelector,
+        mapped_addrs::MappedAddr,
+        remote_map::PathSelector,
+        transports::{RelayConnectionFailure, RelayConnectionState},
     },
     tls::{self, DEFAULT_MAX_TLS_TICKETS, misc::RustlsTokenKey},
 };
@@ -1380,9 +1382,10 @@ impl Endpoint {
     /// The watcher updates whenever any home relay's connection status changes.
     /// See [`RelayStatus`] for the information available on each entry.
     ///
-    /// This may be used to observe connection failures to the home relay.
-    /// The reason for a failure to connect to the home relay can be observed
-    /// via [`RelayStatus::last_error`]. See its docs for details.
+    /// This may be used to observe connection failures to the home relay:
+    /// [`RelayStatus::last_error`] reports the most recent error, and
+    /// [`RelayStatus::auth_denied_reason`] singles out the case of the relay
+    /// server denying the endpoint's authentication.
     ///
     /// The returned watcher only becomes disconnected once the last clone of
     /// the [`Endpoint`] is dropped. Closing the endpoint does not disconnect
@@ -1921,29 +1924,50 @@ impl RelayStatus {
     /// Returns `None` when the relay is connected, or when the endpoint has
     /// not yet observed a failed connection attempt.
     ///
-    /// The returned error is an [`AnyError`]. You can try to downcast the
-    /// error, or any further error in the chain, to a specific type.
+    /// The error is meant to be logged or displayed, not matched on: it is an
+    /// [`AnyError`] wrapping a chain of private error types, none of which are
+    /// covered by semver guarantees. Use [`Self::auth_denied_reason`] to
+    /// distinguish the one failure that usually calls for a different reaction
+    /// than retrying.
+    pub fn last_error(&self) -> Option<&AnyError> {
+        self.state.last_failure().map(RelayConnectionFailure::error)
+    }
+
+    /// Returns the reason if the relay server denied our authentication.
     ///
-    /// For example, the function below will check if the error indicates
-    /// an authentication failure, and if so return the reason for the
-    /// failed authentication as reported by the relay server.
+    /// Unlike most connection failures, this one will not usually resolve
+    /// itself. The endpoint keeps retrying with a backoff, but it presents the
+    /// same credentials every time, so unless the relay's access policy
+    /// changes it will keep being denied and [`Endpoint::online`] will never
+    /// resolve. An application that configures a relay auth token should
+    /// surface this to the user rather than wait to come online.
+    ///
+    /// The returned string is the reason reported by the relay server. It is
+    /// meant to be human-readable, don't attempt to match on it.
+    ///
+    /// Returns `None` when the relay is connected, when no connection attempt
+    /// has failed yet, or when the last failure had another cause.
     ///
     /// ```no_run
-    /// use iroh_relay::protos::handshake;
-    /// use n0_error::{AnyError, StackError};
+    /// # async fn wrapper() -> n0_error::Result<()> {
+    /// use iroh::{Endpoint, Watcher, endpoint::presets};
+    /// use n0_future::StreamExt;
     ///
-    /// /// Returns the reason if `error` was caused by the relay server denying our authentication.
-    /// fn is_auth_denied(error: &AnyError) -> Option<String> {
-    ///     error
-    ///         .stack()
-    ///         .find_map(|error| match error.downcast_ref::<handshake::Error>()? {
-    ///             handshake::Error::ServerDeniedAuth { reason, .. } => Some(reason.clone()),
-    ///             _ => None,
-    ///         })
+    /// let endpoint = Endpoint::builder(presets::Minimal).bind().await?;
+    /// let mut status = endpoint.home_relay_status().stream();
+    /// while let Some(relays) = status.next().await {
+    ///     for relay in relays {
+    ///         if let Some(reason) = relay.auth_denied_reason() {
+    ///             println!("{}: authentication denied ({reason})", relay.url());
+    ///         }
+    ///     }
     /// }
+    /// # Ok(()) }
     /// ```
-    pub fn last_error(&self) -> Option<&AnyError> {
-        self.state.last_error().map(Arc::as_ref)
+    pub fn auth_denied_reason(&self) -> Option<&str> {
+        self.state
+            .last_failure()
+            .and_then(RelayConnectionFailure::auth_denied_reason)
     }
 }
 
@@ -4111,10 +4135,13 @@ mod tests {
     /// Verifies that an endpoint configured with [`RelayConfig::with_auth_token`]
     /// is admitted to a relay whose access control checks the token only when
     /// the token matches.
+    ///
+    /// Also verifies that [`RelayStatus::auth_denied_reason`] works correctly.
     #[tokio::test]
     #[traced_test]
     async fn test_endpoint_relay_auth_token() -> Result {
         const TOKEN: &str = "valid-token";
+        const DENIAL_REASON: &str = "this token is no good";
 
         /// Admits a connection only if it carries the expected auth token.
         #[derive(Debug)]
@@ -4125,7 +4152,9 @@ mod tests {
                 if request.auth_token().as_deref() == Some(self.0) {
                     Access::Allow
                 } else {
-                    Access::Deny { reason: None }
+                    Access::Deny {
+                        reason: Some(DENIAL_REASON.to_string()),
+                    }
                 }
             }
         }
@@ -4133,8 +4162,8 @@ mod tests {
         let access = Arc::new(TokenAccess(TOKEN));
         let (_relay_map, relay_url, _guard) = run_relay_server_with_access(false, access).await?;
 
-        // Wrong token: the connection attempt fails and last_error reports
-        // the relay-side denial.
+        // Wrong token: the connection attempt fails, and the status reports the
+        // relay-side denial both as an error and as an authentication failure.
         let bad_map: RelayMap = RelayConfig::new(relay_url.clone(), None)
             .with_auth_token("wrong-token")
             .into();
@@ -4144,10 +4173,14 @@ mod tests {
             .bind()
             .await?;
         let mut stream = bad_ep.home_relay_status().stream();
-        let auth_err: String = tokio::time::timeout(Duration::from_secs(5), async {
+        let (auth_err, auth_denied_reason) = tokio::time::timeout(Duration::from_secs(5), async {
             while let Some(status) = stream.next().await {
-                if let Some(err) = status.iter().filter_map(|s| s.last_error()).next() {
-                    return format!("{err:#}");
+                if let Some(relay) = status.iter().find(|s| s.last_error().is_some()) {
+                    let err = relay.last_error().expect("checked above");
+                    return (
+                        format!("{err:#}"),
+                        relay.auth_denied_reason().map(ToOwned::to_owned),
+                    );
                 }
             }
             panic!("home relay stream ended");
@@ -4155,8 +4188,13 @@ mod tests {
         .await
         .std_context("waiting for auth error")?;
         assert!(
-            auth_err.contains("not authorized"),
-            "expected 'not authorized' in error, got: {auth_err}"
+            auth_err.contains(DENIAL_REASON),
+            "expected {DENIAL_REASON:?} in error, got: {auth_err}"
+        );
+        assert_eq!(
+            auth_denied_reason.as_deref(),
+            Some(DENIAL_REASON),
+            "auth_denied_reason did not recognise a relay-side denial (error was: {auth_err})"
         );
 
         // Correct token: the endpoint reaches the connected state.

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1380,6 +1380,10 @@ impl Endpoint {
     /// The watcher updates whenever any home relay's connection status changes.
     /// See [`RelayStatus`] for the information available on each entry.
     ///
+    /// This may be used to observe connection failures to the home relay.
+    /// The reason for a failure to connect to the home relay can be observed
+    /// via [`RelayStatus::last_error`]. See its docs for details.
+    ///
     /// The returned watcher only becomes disconnected once the last clone of
     /// the [`Endpoint`] is dropped. Closing the endpoint does not disconnect
     /// the watcher. To stop a task once the endpoint stops, combine with
@@ -1910,11 +1914,32 @@ impl RelayStatus {
         self.state.is_connected()
     }
 
-    /// Returns the most recent connection error, if the relay is currently
-    /// disconnected.
+    /// Returns the most recent connection error.
     ///
     /// Returns `None` when the relay is connected, or when the endpoint has
     /// not yet observed a failed connection attempt.
+    ///
+    /// The returned error is an [`AnyError`]. You can try to downcast the
+    /// error, or any further error in the chain, to a specific type.
+    ///
+    /// For example, the function below will check if the error indicates
+    /// an authentication failure, and if so return the reason for the
+    /// failed authentication as reported by the relay server.
+    ///
+    /// ```no_run
+    /// use iroh_relay::protos::handshake;
+    /// use n0_error::{AnyError, StackError};
+    ///
+    /// /// Returns the reason if `error` was caused by the relay server denying our authentication.
+    /// fn is_auth_denied(error: &AnyError) -> Option<String> {
+    ///     error
+    ///         .stack()
+    ///         .find_map(|error| match error.downcast_ref::<handshake::Error>()? {
+    ///             handshake::Error::ServerDeniedAuth { reason, .. } => Some(reason.clone()),
+    ///             _ => None,
+    ///         })
+    /// }
+    /// ```
     pub fn last_error(&self) -> Option<&AnyError> {
         self.state.last_error().map(Arc::as_ref)
     }

--- a/iroh/src/endpoint.rs
+++ b/iroh/src/endpoint.rs
@@ -1950,6 +1950,8 @@ impl RelayStatus {
     ///
     /// ```no_run
     /// # async fn wrapper() -> n0_error::Result<()> {
+    /// # #[cfg(with_crypto_provider)]
+    /// # {
     /// use iroh::{Endpoint, Watcher, endpoint::presets};
     /// use n0_future::StreamExt;
     ///
@@ -1962,6 +1964,7 @@ impl RelayStatus {
     ///         }
     ///     }
     /// }
+    /// # }
     /// # Ok(()) }
     /// ```
     pub fn auth_denied_reason(&self) -> Option<&str> {

--- a/iroh/src/socket/transports.rs
+++ b/iroh/src/socket/transports.rs
@@ -36,7 +36,7 @@ pub(crate) use self::ip::Config as IpConfig;
 #[cfg(not(wasm_browser))]
 use self::ip::{IpNetworkChangeSender, IpTransports, IpTransportsSender};
 pub(crate) use self::relay::{
-    HomeRelayWatch, RelayActorConfig, RelayConnectionState, RelayTransport,
+    HomeRelayWatch, RelayActorConfig, RelayConnectionFailure, RelayConnectionState, RelayTransport,
 };
 
 /// How many times all transports may error on `poll_recv` before we give up.

--- a/iroh/src/socket/transports/relay.rs
+++ b/iroh/src/socket/transports/relay.rs
@@ -21,7 +21,9 @@ use crate::endpoint::RelayStatus;
 
 mod actor;
 
-pub(crate) use self::actor::{Config as RelayActorConfig, HomeRelayWatch, RelayConnectionState};
+pub(crate) use self::actor::{
+    Config as RelayActorConfig, HomeRelayWatch, RelayConnectionFailure, RelayConnectionState,
+};
 use self::actor::{RelayActor, RelayActorMessage, RelayRecvDatagram, RelaySendItem};
 
 type RelayAddrWatcher =

--- a/iroh/src/socket/transports/relay/actor.rs
+++ b/iroh/src/socket/transports/relay/actor.rs
@@ -42,7 +42,10 @@ use iroh_base::{EndpointId, RelayUrl, SecretKey};
 use iroh_relay::{
     self as relay, PingTracker, RelayMap,
     client::{Client, ConnectError, RecvError, SendError},
-    protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg, Status},
+    protos::{
+        handshake,
+        relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg, Status},
+    },
 };
 use n0_error::{AnyError, e, stack_error};
 use n0_future::{
@@ -326,9 +329,11 @@ impl ActiveRelayActor {
         while let Err(err) = self.run_once().await {
             warn!("{err:#}");
             let was_established = matches!(err, RelayConnectionError::Established { .. });
-            let last_error = Some(Arc::new(AnyError::from(err)));
-            self.my_relay
-                .set_status(&self.url, RelayConnectionState::Disconnected { last_error });
+            let last_failure = Some(Arc::new(RelayConnectionFailure::new(err)));
+            self.my_relay.set_status(
+                &self.url,
+                RelayConnectionState::Disconnected { last_failure },
+            );
             if !was_established {
                 // If dialing failed, or if the relay connection failed before we received a pong,
                 // we wait an exponentially increasing time until we attempt to reconnect again.
@@ -962,13 +967,15 @@ pub(crate) enum RelayConnectionState {
     /// Not connected. Either the connection was lost after having been
     /// established, or an attempt to connect failed.
     ///
-    /// `last_error` carries the most recent connection error, if any. The
+    /// `last_failure` carries the most recent connection failure, if any. The
     /// initial transition into this state (before any attempt has produced
     /// an error) carries `None`.
     ///
     /// The `Arc` is compared by pointer identity: each new failure produces
     /// a fresh allocation, so the watcher fires on every new error.
-    Disconnected { last_error: Option<Arc<AnyError>> },
+    Disconnected {
+        last_failure: Option<Arc<RelayConnectionFailure>>,
+    },
 }
 
 impl RelayConnectionState {
@@ -976,9 +983,9 @@ impl RelayConnectionState {
         matches!(self, Self::Connected)
     }
 
-    pub(crate) fn last_error(&self) -> Option<&Arc<AnyError>> {
+    pub(crate) fn last_failure(&self) -> Option<&RelayConnectionFailure> {
         match self {
-            Self::Disconnected { last_error } => last_error.as_ref(),
+            Self::Disconnected { last_failure } => last_failure.as_deref(),
             _ => None,
         }
     }
@@ -988,7 +995,7 @@ impl PartialEq for RelayConnectionState {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Connecting, Self::Connecting) | (Self::Connected, Self::Connected) => true,
-            (Self::Disconnected { last_error: a }, Self::Disconnected { last_error: b }) => {
+            (Self::Disconnected { last_failure: a }, Self::Disconnected { last_failure: b }) => {
                 match (a, b) {
                     (None, None) => true,
                     (Some(a), Some(b)) => Arc::ptr_eq(a, b),
@@ -1001,6 +1008,54 @@ impl PartialEq for RelayConnectionState {
 }
 
 impl Eq for RelayConnectionState {}
+
+/// A failed attempt to connect to a relay server, or a lost connection.
+///
+/// Contains the type-erased error, together with whatever we could classify from it
+/// while the concrete error type was still at hand.
+#[derive(Debug)]
+pub(crate) struct RelayConnectionFailure {
+    error: AnyError,
+    auth_denied_reason: Option<String>,
+}
+
+impl RelayConnectionFailure {
+    fn new(error: RelayConnectionError) -> Self {
+        Self {
+            auth_denied_reason: auth_denied_reason(&error).map(ToOwned::to_owned),
+            error: AnyError::from(error),
+        }
+    }
+
+    /// Returns the type-erased error.
+    pub(crate) fn error(&self) -> &AnyError {
+        &self.error
+    }
+
+    /// Returns the reason if the relay server denied our authentication.
+    pub(crate) fn auth_denied_reason(&self) -> Option<&str> {
+        self.auth_denied_reason.as_deref()
+    }
+}
+
+/// Returns the reason if `error` was caused by the relay server denying our authentication.
+fn auth_denied_reason(error: &RelayConnectionError) -> Option<&str> {
+    match error {
+        RelayConnectionError::Dial {
+            source:
+                DialError::Connect {
+                    source:
+                        ConnectError::Handshake {
+                            source: handshake::Error::ServerDeniedAuth { reason, .. },
+                            ..
+                        },
+                    ..
+                },
+            ..
+        } => Some(reason),
+        _ => None,
+    }
+}
 
 /// Shared watchable for the home relay URL and connection status.
 ///
@@ -1953,7 +2008,10 @@ mod tests {
         watch.set(b.clone(), RelayConnectionState::Connecting);
 
         // Old actor A tries to write -- rejected because URL changed
-        watch.set_status(&a, RelayConnectionState::Disconnected { last_error: None });
+        watch.set_status(
+            &a,
+            RelayConnectionState::Disconnected { last_failure: None },
+        );
         assert_eq!(
             watch.get(),
             Some(RelayStatus::new(


### PR DESCRIPTION
## Description

This adds `RelayStatus::auth_denied_reason`, which returns `Some(reason_string)` if the last connection attempt to the relay failed with an authentication failure.

We already have `RelayStatus::last_error`, which returns the type-erased error from the last connection as `AnyError`. While it is technically possible to downcast from that to the handshake error that it contains if we have an authentication failure, it is deeply nested in a chain of non-public errors, not covered by any semver guarantees, and hard to find out for users. Likely we should've added an error enum here instead so that we can add new variants, but that would be a breaking change.

Most other errors are some kind of connection error anyway, which usually are enough to print and log. Authentication is different: You'd want to raise this to the user, because it will usually be the result of incorrect confirmation, expired tokens, or similar. 

This PR adds a simple way to do that. It also adds an example to show how to, and expands the docs around this.


## Breaking Changes

None

## Notes & open questions

Fixes #4433.

Also: here's a screenshot of the output of the example when connecting to an authenticated relay without providing a token. First without tracing logs, second with `RUST_LOG=info`.

<img width="1492" height="906" alt="Screenshot From 2026-09-02 10-08-32" src="https://github.com/user-attachments/assets/38b98e29-b484-4253-a52e-9f8b5e40c8b8" />


## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
