### PR TITLE
feat(iroh-dns): Deprecate old nameserver builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arc-swap",
  "cfg_aliases",

--- a/iroh-dns-server/tests/patchbay.rs
+++ b/iroh-dns-server/tests/patchbay.rs
@@ -16,11 +16,9 @@
 // via a cfg directive
 #![cfg(all(target_os = "linux", not(skip_patchbay)))]
 
-use std::{
-    net::{IpAddr, SocketAddr},
-    time::Duration,
-};
+use std::{net::IpAddr, time::Duration};
 
+use iroh::dns::NameserverConfig;
 use iroh_base::SecretKey;
 use iroh_dns::{
     dns::{DnsProtocol, DnsResolver},
@@ -169,8 +167,13 @@ async fn check_reachable(ip: IpAddr, ports: Ports) -> Result {
     // (the DNS server binds both on the same address).
     let name = format!("_iroh.{z32}.irohdns.example.");
     for protocol in [DnsProtocol::Udp, DnsProtocol::Tcp] {
+        let nameserver = match protocol {
+            DnsProtocol::Udp => NameserverConfig::udp(ip).with_port(ports.dns),
+            DnsProtocol::Tcp => NameserverConfig::tcp(ip).with_port(ports.dns),
+            _ => unreachable!(),
+        };
         let resolver = DnsResolver::builder()
-            .with_nameserver(SocketAddr::new(ip, ports.dns), protocol)
+            .add_nameserver_config(nameserver)
             .build();
         let records: Vec<String> = resolver
             .lookup_txt(&name, Duration::from_secs(5))

--- a/iroh-dns/Cargo.toml
+++ b/iroh-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-dns"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 description = "DNS-based endpoint discovery for iroh"
 license = "MIT OR Apache-2.0"

--- a/iroh-dns/src/dns.rs
+++ b/iroh-dns/src/dns.rs
@@ -416,6 +416,7 @@ impl Builder {
     /// IP address. To set a different one, build a [`NameserverConfig`] with
     /// [`NameserverConfig::with_tls_server_name`] and pass it to
     /// [`Self::add_nameserver_config`].
+    #[deprecated(since = "1.2.0", note = "use add_nameserer_config()")]
     pub fn with_nameserver(mut self, addr: SocketAddr, protocol: DnsProtocol) -> Self {
         self.nameservers.push(NameserverConfig {
             addr,
@@ -431,6 +432,7 @@ impl Builder {
     /// IP address. To set a different one, build a [`NameserverConfig`] with
     /// [`NameserverConfig::with_tls_server_name`] and pass it to
     /// [`Self::add_nameserver_configs`].
+    #[deprecated(since = "1.2.0", note = "use add_nameserer_configs()")]
     pub fn with_nameservers(
         mut self,
         nameservers: impl IntoIterator<Item = (SocketAddr, DnsProtocol)>,


### PR DESCRIPTION
## Description

This deprecates the old nameserver config builders in favour of the
new ones that are more consistent.

## API Changes

- `iroh_dns::dns::Builder::with_nameserver` -> `add_nameserver`
- `iroh_dns::dns::Builder::with_nameservers` -> `add_nameservers`

The `iroh_dns::dns` module is also re-exported as  `iroh::dns`.

## Notes & open questions

- min-crates fails because it needs to select n0-dns-resolver which is not yet 3 days old.
- I had to bump the version of iroh-dns to make the semver CI check happy.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.