### PR TITLE
chore: Update PR template for API changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,20 +2,20 @@
 
 <!-- A summary of what this pull request achieves and a rough list of changes. -->
 
-## Breaking Changes
+## API Changes
 
-<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
+<!-- Optional, any API additions, deprecations or breaking changes, including how to migrate older code. -->
 
 ## Notes & open questions
 
 <!-- Any notes, remarks or open questions you have to make about the PR. -->
 
 ## Change checklist
-<!-- Remove any that are not relevant. -->
+
 - [ ] Self-review.
 - [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
 - [ ] Tests if relevant.
-- [ ] All breaking changes documented.
+- [ ] All API changes documented.
 - [ ] This PR was created by a human that thought critically about the
       proposed change and wrote an as clear and concise description as
       they could.


### PR DESCRIPTION
## Description

This aligns with a change started in noq:

- Mention API changes rather than breaking changes.

- Do not encourage to remote checkboxes. That leaves me guessing what
  the template *should* look like in each repo.

## Breaking Changes

n/a

## Notes & open questions

Equivalent noq pr: https://github.com/n0-computer/noq/pull/796

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.