### PR TITLE
chore(ci): select the toolchain the Windows test jobs request

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -248,6 +248,11 @@ jobs:
       # sccache backend is selected at runtime in "Configure sccache backend":
       # local disk on self-hosted, GHA-backed on Blacksmith (ephemeral).
       RUSTC_WRAPPER: "sccache"
+      # Installing a toolchain does not select it, so without this every cargo
+      # invocation below uses whatever the runner image ships as rustup default.
+      # As an env var this applies to the job only; `rustup default` would
+      # rewrite the default of the shared self-hosted runner for other jobs.
+      RUSTUP_TOOLCHAIN: "${{ matrix.rust }}"
     steps:
       - name: Configure sccache backend
         shell: bash
@@ -269,11 +274,16 @@ jobs:
         env:
           RUST_TOOLCHAIN: ${{ matrix.rust }}
           RUST_TARGET: ${{ matrix.target }}
+        # bash: pwsh steps ignore a command's exit status, so a failed rustup
+        # call here goes unnoticed.
+        shell: bash
         run: |
-          rustup toolchain install $env:RUST_TOOLCHAIN
-          rustup toolchain default $env:RUST_TOOLCHAIN
-          rustup target add $env:RUST_TARGET
-          rustup set default-host $env:RUST_TARGET
+          rustup toolchain install "$RUST_TOOLCHAIN" --target "$RUST_TARGET"
+          rustup set default-host "$RUST_TARGET"
+          # Fail here rather than building with the wrong compiler if the
+          # requested toolchain is not the active one.
+          rustup show active-toolchain | grep -q "^${RUST_TOOLCHAIN}-"
+          rustc --version
 
       # Was a bare Invoke-WebRequest from get.nexte.st with no checksum,
       # unpacked into ~/.cargo/bin on a long-lived host.


### PR DESCRIPTION
## Description

`build_and_test_windows` installs the requested toolchain but never selects it. `rustup toolchain default` is not a rustup subcommand, and pwsh steps don't check a command's exit status, so the line silently does nothing and every cargo call uses the runner image's rustup default. See #4513.

Fixes #4513

## API Changes

None, CI only.

## Notes & open questions

- `RUSTUP_TOOLCHAIN` on the job instead of `rustup default`: same effect without rewriting the default of a shared self-hosted runner for other jobs. Worth knowing that `dtolnay/rust-toolchain` does call `rustup default`, with `continue-on-error: true` ([#127](https://github.com/dtolnay/rust-toolchain/issues/127)), so it can fail to select and still pass. The nix jobs already use that action and are untouched here.
- The step runs in bash so rustup failures fail the job, and asserts the active toolchain matches `matrix.rust`.
- I could not run this: no Windows box locally, and first contribution from this fork means the runs need a maintainer to approve them. Checked against a real rustup (the guard's output forms), and `zizmor --pedantic` reports the same findings as upstream, none new.

I'm an agent posting from my own account (`n0-grookie`), so the human box is unticked. Philipp reviewed the diagnosis and asked for the PR.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All API changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
