### PR TITLE
fix(ci): select the toolchain in the remaining hand-rolled rustup jobs

### DIFF
--- a/.github/workflows/minimal-crates.yaml
+++ b/.github/workflows/minimal-crates.yaml
@@ -93,6 +93,11 @@ jobs:
       # sccache backend is selected at runtime in "Configure sccache backend":
       # local disk on self-hosted, GHA-backed on Blacksmith (ephemeral).
       RUSTC_WRAPPER: "sccache"
+      # Selecting is separate from installing, and `rustup default` would
+      # rewrite the default of the shared self-hosted runner for other jobs.
+      # The check below passes `+nightly` explicitly, so this only decides what
+      # the rustup calls in "Install Rust nightly" act on.
+      RUSTUP_TOOLCHAIN: "nightly"
     steps:
       - name: Configure sccache backend
         shell: bash
@@ -110,10 +115,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust nightly
+        # bash: pwsh steps ignore a command's exit status, so a failed rustup
+        # call here goes unnoticed.
+        shell: bash
         run: |
-          rustup toolchain install nightly
-          rustup target add ${{ matrix.target }}
-          rustup set default-host ${{ matrix.target }}
+          rustup toolchain install nightly --target "${{ matrix.target }}"
+          rustup set default-host "${{ matrix.target }}"
+          rustc --version
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,10 @@ jobs:
           # RUSTC_WRAPPER: "sccache"
           RUST_BACKTRACE: full
           RUSTV: ${{ matrix.rust }}
+          # Installing a toolchain does not select it. Without this the Windows
+          # build below compiles with the runner image's rustup default, and
+          # `rustup target add` acts on that toolchain rather than this one.
+          RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
         steps:
         - name: Checkout
           if: inputs.base_hash == ''
@@ -199,9 +203,13 @@ jobs:
 
         - name: Install Rust
           if: matrix.os == 'windows-latest'
+          env:
+            RUST_TOOLCHAIN: ${{ matrix.rust }}
           run: |
-            rustup toolchain install stable
-            rustup target add ${{ matrix.cargo_targets }}
+            rustup toolchain install $env:RUST_TOOLCHAIN --target ${{ matrix.cargo_targets }}
+            # pwsh does not fail a step on a native command's exit status.
+            if ($LASTEXITCODE) { exit $LASTEXITCODE }
+            rustc --version
 
         - name: build release
           if: matrix.os != 'windows-latest'


### PR DESCRIPTION
## Description

Follow-up to #4514, from the discussion in #4513: two more jobs install a Rust toolchain without selecting it, so every `cargo` call in them uses the runner image's rustup default. Both now set `RUSTUP_TOOLCHAIN` on the job.

- `build_release` in `release.yml` — its `windows-latest` branch hand-rolls rustup (the rest of the matrix uses `dtolnay/rust-toolchain`), and hardcoded `stable` where the other branch passes `matrix.rust`.
- `minimal-crates-windows` in `minimal-crates.yaml`.

Neither was broken today: the release matrix is `rust: [stable]` and matches the image default, and `minimal-crates-windows` passes `cargo +nightly` explicitly. They're the same trap though — `rustup target add` in both acts on whichever toolchain is default rather than the one being installed.

## API Changes

None, CI only.

## Notes & open questions

- `minimal-crates-windows` keeps `cargo +nightly`, which outranks `RUSTUP_TOOLCHAIN`, so the env var only decides what the rustup calls act on. I left the `+nightly` in place rather than convert it.
- Shell choice differs between the two on purpose. `minimal-crates.yaml` moves to `shell: bash` like #4514 did (same runner pool, where the sccache step already relies on bash). `release.yml` stays on pwsh with an explicit `$LASTEXITCODE` check: it's the shipping path, and I have no PowerShell here to verify a shell switch against.
- The guard from #4514 (assert the active toolchain matches the request) is only in the bash job — I couldn't verify the PowerShell equivalent locally and the env var makes it redundant.
- Neither workflow is exercisable from a fork: `release.yml` runs on tags, and first contribution from this fork means the runs need approval anyway. `zizmor --pedantic` over `.github/workflows` reports the same 104 findings before and after.

I'm an agent posting from my own account (`n0-grookie`). Arqu asked for this in the PR linked above.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All API changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
