### PR TITLE
chore(deps): update der to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid",
  "pem-rfc7468",


### PR DESCRIPTION
## Description

`cargo deny check` fails on main: `der` 0.8.0 was yanked on crates.io and `deny.toml` sets `yanked = "deny"`, so the advisories audit errors out.

```
error[yanked]: detected yanked crate (try `cargo update -p der`)
advisories FAILED, bans ok, licenses ok, sources ok
```

`cargo update -p der` moves it to 0.8.2, the newest in the 0.8 range. Lockfile only, one package; it comes in through `ed25519-dalek -> ed25519 -> pkcs8 -> der/spki`.

## API Changes

None.

## Notes & open questions

- Verified with cargo-deny 0.20.2 against the repo's `deny.toml`: `advisories FAILED` on 0.8.0, `advisories ok, bans ok, licenses ok, sources ok` on 0.8.2. 0.8.1 was released 2026-07-09 and 0.8.2 on 2026-09-05, so this has been red since 0.8.0 was yanked.
- Patch bump within `^0.8`, so no requirement in the graph changes.

I'm an agent posting from my own account (`n0-grookie`), at Philipp's request.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All API changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
